### PR TITLE
Kronborgs patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It's open-source, so feel free to add or remove anything you want! Feedback is a
 
 As of now, only build 22621.525 (the one that can be downloaded from the Microsoft website), 22621.1265 (the latest public build) and 25300 (latest Insider build as of now) are supported.
 
+but do NOT use the oscdimg.exe as the signing is missing a proper timestamp. Always use official Microsoft tools from their website. oscdimg.exe is included in the Windows ADK Package located @ https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install
+
+Why should you not trust digital signatures - Check out the latest hack from 3cx and it exploiting them in this article: https://www.bleepingcomputer.com/news/microsoft/10-year-old-windows-bug-with-opt-in-fix-exploited-in-3cx-attack/
+
 Instructions:
 
 1. Download Windows 11 22621.1265 from UUPDump or 22621.525 or 25300 from the Microsoft website (<https://www.microsoft.com/software-download/windows11>)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It's open-source, so feel free to add or remove anything you want! Feedback is a
 
 As of now, only build 22621.525 (the one that can be downloaded from the Microsoft website), 22621.1265 (the latest public build) and 25300 (latest Insider build as of now) are supported.
 
-but do NOT use the oscdimg.exe as the signing is missing a proper timestamp. Always use official Microsoft tools from their website. oscdimg.exe is included in the Windows ADK Package located @ https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install
+# but do NOT use the oscdimg.exe as the signing is missing a proper timestamp. Always use official Microsoft tools from their website. oscdimg.exe is included in the Windows ADK Package located @ https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install
 
 Why should you not trust digital signatures - Check out the latest hack from 3cx and it exploiting them in this article: https://www.bleepingcomputer.com/news/microsoft/10-year-old-windows-bug-with-opt-in-fix-exploited-in-3cx-attack/
 

--- a/tiny11 creator 25300.bat
+++ b/tiny11 creator 25300.bat
@@ -119,9 +119,9 @@ dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-TabletP
 echo Removing Wallpapers:
 dism /image:c:\scratchdir /Remove-Package /PackageName:Microsoft-Windows-Wallpaper-Content-Extended-FoD-Package~31bf3856ad364e35~amd64~~10.0.25300.1000 > nul
 
-echo Removing Edge:
-rd "C:\scratchdir\Program Files (x86)\Microsoft\Edge" /s /q
-rd "C:\scratchdir\Program Files (x86)\Microsoft\EdgeUpdate" /s /q
+REM echo Removing Edge:
+REM rd "C:\scratchdir\Program Files (x86)\Microsoft\Edge" /s /q
+REM rd "C:\scratchdir\Program Files (x86)\Microsoft\EdgeUpdate" /s /q
 echo Removing OneDrive:
 takeown /f C:\scratchdir\Windows\System32\OneDriveSetup.exe
 icacls C:\scratchdir\Windows\System32\OneDriveSetup.exe /grant Administrators:F /T /C


### PR DESCRIPTION
> Delete strange oscdimg.exe, too.



You can automatically download a signed Oscdimg binary directly from Microsoft without having to install Windows ADK https://github.com/ntdevlabs/tiny11builder/pull/43#issuecomment-1501074660.

This would be more seamless than having to install Windows ADK just for the Oscdimg binary.